### PR TITLE
fix error with DT looking for column names passed as single variable

### DIFF
--- a/R/fortify.R
+++ b/R/fortify.R
@@ -173,12 +173,12 @@ fortify_mutation_calls = function(x)
     )
   }
 
-  if(x[, required_columns] %>% is.na() %>% any()){
+  if(x[, ..required_columns] %>% is.na() %>% any()){
     cli::cli_alert_danger(
       "NA values in some of the required mutation columns, these will be removed."
     )
 
-    x = x[complete.cases(x[, required_columns]), ]
+    x = x[complete.cases(x[, ..required_columns]), ]
 
     if(nrow(x) == 0) stop("No more mutations to work with?")
   }

--- a/R/fortify.R
+++ b/R/fortify.R
@@ -173,12 +173,12 @@ fortify_mutation_calls = function(x)
     )
   }
 
-  if(x[, ..required_columns] %>% is.na() %>% any()){
+  if(x[, eval(required_columns)] %>% is.na() %>% any()){
     cli::cli_alert_danger(
       "NA values in some of the required mutation columns, these will be removed."
     )
 
-    x = x[complete.cases(x[, ..required_columns]), ]
+    x = x[complete.cases(x[, eval(required_columns)]), ]
 
     if(nrow(x) == 0) stop("No more mutations to work with?")
   }


### PR DESCRIPTION
Hello,

I recently attempted to build a CNAqc object using the `init()` function after building the individual data frames required, as described in the [vignette.](https://caravagnalab.github.io/CNAqc/articles/a1_Introduction.html).

However, despite confirming the correct column names...
```{r}
> colnames(testsample_mutations)
[1] "chr"  "from" "to"   "ref"  "alt"  "DP"   "NV"   "VAF" 
> colnames(testsample_cna)
[1] "chr"   "from"  "to"    "Major" "minor"
```

The following error continued to occur:
```{r}
testsample_cnaqc <- CNAqc::init(mutations = testsample_mutations,
                                                          cna = testsample_cna,
                                                          purity = testsample_purity,
                                                          sample = "testsample",
                                                          ref = "GRCh38")

Error in `[.data.table`(x, , required_columns) : 
  j (the 2nd argument inside [...]) is a single symbol but column name 'required_columns' is not found.
  If you intended to select columns using a variable in calling scope, please try DT[, ..required_columns].
  The .. prefix conveys one-level-up similar to a file system path.
```

As the error message suggested, I added the prefix of `..` to the issue spots in the `fortify_mutation_calls()` function. After re-installing with the edits, the error is resolved.

```{r}
testsample_cnaqc <- CNAqc::init(mutations = testsample_mutations,
                                                          cna = testsample_cna,
                                                          purity = testsample_purity,
                                                          sample = "testsample",
                                                          ref = "GRCh38")

── CNAqc - CNA Quality Check ──────────────────────────────────────────────────────

ℹ Using reference genome coordinates for: GRCh38.
✔ Fortified calls for 11236 somatic mutations: 11236 SNVs (100%) and 0 indels.
! CNAs have no CCF, assuming clonal CNAs (CCF = 1).
✖ 23 NA entrie(s) in clonal CNAs; segments will be removed.
! Added segments length (in basepairs) to CNA segments.
✔ Fortified CNAs for 543 segments: 543 clonal and 0 subclonal.
✔ 11130 mutations mapped to clonal CNAs.   
```

I believe this issue stems from updates to `data.table`. Here is the session information:

```{r}
R version 4.5.1 (2025-06-13)
Platform: x86_64-apple-darwin20
Running under: macOS Sequoia 15.6.1

Matrix products: default
BLAS:   /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libBLAS.dylib 
LAPACK: /Library/Frameworks/R.framework/Versions/4.5-x86_64/Resources/lib/libRlapack.dylib;  LAPACK version 3.12.1

locale:
[1] en_US.UTF-8/en_US.UTF-8/en_US.UTF-8/C/en_US.UTF-8/en_US.UTF-8

time zone: America/New_York
tzcode source: internal

attached base packages:
[1] parallel  stats4    stats     graphics  grDevices utils     datasets  methods   base     

other attached packages:
 [1] CNAqc_1.1.2                       gGnome_0.1                        igraph_2.1.4                      Matrix_1.7-3                      R6_2.6.1                         
 [6] R.utils_2.13.0                    R.oo_1.27.1                       R.methodsS3_1.8.2                 doParallel_1.0.17                 iterators_1.0.14                 
[11] foreach_1.5.2                     mclust_6.1.1                      flextable_0.9.9                   scico_1.5.0                       paletteer_1.6.0                  
[16] ggsci_3.2.0                       ggplot2_3.5.2                     readr_2.1.5                       stringr_1.5.1                     dplyr_1.1.4                      
[21] VariantAnnotation_1.54.1          Rsamtools_2.24.0                  SummarizedExperiment_1.38.1       Biobase_2.68.0                    MatrixGenerics_1.20.0            
[26] matrixStats_1.5.0                 gUtils_0.2.0                      BSgenome.Hsapiens.UCSC.hg38_1.4.5 BSgenome_1.76.0                   rtracklayer_1.68.0               
[31] BiocIO_1.18.0                     Biostrings_2.76.0                 XVector_0.48.0                    GenomicRanges_1.60.0              GenomeInfoDb_1.44.2              
[36] IRanges_2.42.0                    S4Vectors_0.46.0                  BiocGenerics_0.54.0               generics_0.1.4                    devgru_0.99.0                    
[41] suncalc_0.5.1                     ipapi_0.1                         data.table_1.17.8                 colorout_1.3-3                   

loaded via a namespace (and not attached):
  [1] akima_0.6-3.6            rsthemes_0.5.0           bitops_1.0-9             tibble_3.3.0             XML_3.99-0.19            rpart_4.1.24             lifecycle_1.0.4         
  [8] rstatix_0.7.2            lattice_0.22-7           backports_1.5.0          magrittr_2.0.3           plotly_4.11.0            rmarkdown_2.29           yaml_2.3.10             
 [15] zip_2.3.3                askpass_1.2.1            ggside_0.3.1             sp_2.2-0                 easypar_1.0.0            cowplot_1.2.0            pbapply_1.7-2           
 [22] DBI_1.2.3                RColorBrewer_1.1-3       lubridate_1.9.4          abind_1.4-8              purrr_1.1.0              RCurl_1.98-1.17          gdtools_0.4.2           
 [29] GenomeInfoDbData_1.2.14  ggrepel_0.9.6            pio_0.1.0                codetools_0.2-20         DelayedArray_0.34.1      xml2_1.3.8               DNAcopy_1.82.0          
 [36] tidyselect_1.2.1         UCSC.utils_1.4.0         farver_2.1.2             ggpie_0.2.5              GenomicAlignments_1.44.0 jsonlite_2.0.0           Formula_1.2-5           
 [43] ggridges_0.5.6           systemfonts_1.2.3        tools_4.5.1              ggnewscale_0.5.2         progress_1.2.3           ragg_1.4.0               pak_0.9.0               
 [50] Rcpp_1.1.0               glue_1.8.0               SparseArray_1.8.1        xfun_0.52                DESeq2_1.48.1            withr_3.0.2              fastmap_1.2.0           
 [57] clisymbols_1.2.0         openssl_2.3.3            digest_0.6.37            timechange_0.3.0         textshaping_1.0.1        gtools_3.9.5             dichromat_2.0-0.1       
 [64] RSQLite_2.4.3            tidyr_1.3.1              fontLiberation_0.1.0     prettyunits_1.2.0        httr_1.4.7               htmlwidgets_1.6.4        S4Arrays_1.8.1          
 [71] fishHook_0.1             librarian_1.8.1          pkgconfig_2.0.3          gtable_0.3.6             blob_1.2.4               htmltools_0.5.8.1        fontBitstreamVera_0.1.1 
 [78] carData_3.0-5            fgsea_1.34.0             paint_0.1.7              scales_1.4.0             png_0.1-8                knitr_1.50               rstudioapi_0.17.1       
 [85] uuid_1.2-1               tzdb_0.5.0               reshape2_1.4.4           rjson_0.2.23             curl_7.0.0               cachem_1.1.0             zoo_1.8-14              
 [92] AnnotationDbi_1.70.0     restfulr_0.0.16          pillar_1.11.0            grid_4.5.1               vctrs_0.6.5              ggpubr_0.6.1             ggfittext_0.10.2        
 [99] car_3.1-3                evaluate_1.0.4           GenomicFeatures_1.60.0   cli_3.6.5                locfit_1.5-9.12          compiler_4.5.1           rlang_1.1.6             
[106] crayon_1.5.3             ggsignif_0.6.4           gTrack_0.1.0             rematch2_2.1.2           plyr_1.8.9               fs_1.6.6                 stringi_1.8.7           
[113] viridisLite_0.4.2        BiocParallel_1.42.1      lazyeval_0.2.2           fontquiver_0.2.1         hms_1.1.3                patchwork_1.3.1          bit64_4.6.0-1           
[120] KEGGREST_1.48.1          broom_1.0.9              memoise_2.0.1            fastmatch_1.1-6          bit_4.6.0                officer_0.6.10          
```